### PR TITLE
Add instructions to run the interface on the RPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,12 @@
 cmake_minimum_required(VERSION 3.8)
 
+include(FetchContent)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(JSON_ImplicitConversions OFF) # deactivate implicit type conversion
 
-project(demo_package)
+project(fcc_bridge)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
@@ -16,14 +18,25 @@ find_package(nlohmann_json REQUIRED)  # JSON library
 find_package(rclcpp REQUIRED)
 find_package(interfaces REQUIRED)
 find_package(common_package REQUIRED)
+find_package(MAVSDK REQUIRED)
 
 include_directories(include)
 
-add_executable(demo_node src/main.cpp)
-ament_target_dependencies(demo_node rclcpp interfaces common_package nlohmann_json)
+add_executable(fcc_bridge
+        src/main.cpp
+        src/fcc_bridge_node_ros.cpp
+        src/fcc_bridge_node_mavsdk.cpp
+        src/fcc_bridge_node_conversion.cpp
+)
+
+target_link_libraries(fcc_bridge
+        MAVSDK::mavsdk
+)
+
+ament_target_dependencies(fcc_bridge rclcpp interfaces common_package nlohmann_json)
 
 install (TARGETS
-  demo_node
+  fcc_bridge
   DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# FCC bridge
+Node with mavlink access. It verifies and sends waypoints requested by other nodes. Also handles RTH and landing.
+
+## Setup on the Raspberry Pi
+
+1. Clone the **thi-drone-ws** repo to the Pi
+1. Enter the `.devcontainer` directory and build the docker container. Don't forget to set the username.
+    ```
+    docker build -t devcontainer --build-arg="USERNAME=admin"
+    ```
+1. Run the container with the following args:
+    ```
+    docker run -ti -d --device=/dev/serial0 -ti -v ~/thi-drone-ws:/home/ws --name thi_drohne devcontainer bash
+    ```
+1. Attach to the container:
+    ```
+    docker attach thi_drohne
+    ```
+1. Install mavsdk:
+    ```
+    wget https://github.com/mavlink/MAVSDK/releases/download/v2.9.1/libmavsdk-dev_2.9.1_debian12_arm64.deb
+    sudo dpkg -i libmavsdk-dev_2.9.1_debian12_arm64.deb
+    ```
+1. Create a parameter file, for example `uav_params.yaml` to set the `UAV_ID` ROS parameter (here I set it to team red):
+    ```
+    fcc_bridge:
+      ros__parameters:
+        UAV_ID: "UAV_TEAM_RED"
+    ```
+1. Build the package:
+    ```
+    colcon build --symlink-install --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --package-up-to fcc_bridge
+    ```
+1. Become **root** to have permissions to write the serial device:
+    ```
+    sudo -i
+    cd /home/ws
+    source /opt/ros/humble/setup.bash
+    . install/setup.bash
+    ```
+1. Finally run the node:
+    ```
+    ros2 run fcc_bridge fcc_bridge --ros-args --params-file /home/ws/uav_params.yaml
+    ```

--- a/package.xml
+++ b/package.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>demo_package</name>
-  <version>0.0.0</version>
-  <description>TODO: Package description</description>
-  <maintainer email="phg6386@thi.de">philipp</maintainer>
+  <name>fcc_bridge</name>
+  <version>0.1.0</version>
+  <description>Bridge between the FCC and the ROS network. Implements safety checks.</description>
+  <maintainer email="job8197@thi.de">Johan</maintainer>
   <license>MIT</license>
-  <url>https://github.com/THI-Drone/demo_package</url>
-  <author email="pgh6386@thi.de">philipp</author>
+  <url>https://github.com/THI-Drone/fcc_bridge_package</url>
+  <author email="job8197@thi.de">Johan</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
I tested the current state of [feat-inital-work](/THI-Drone/fcc_bridge_package/tree/feat-inital-work) on the Pi4 in the lab. I'm happy to report that the connection to the FCC is working! Therefore I added this readme with instructions to replicate what I did today.